### PR TITLE
Fix Luftdruck program declarations

### DIFF
--- a/Luftdruck-Messprogramm
+++ b/Luftdruck-Messprogramm
@@ -4,12 +4,12 @@
 using namespace std;
 
 int main() {
-/*    const int ballons = 4;
+    const int ballons = 4;
     const int months = 3;
     double pressure[months][ballons] = {
         {1.37, 0.78, 0.93, 1.14},
         {0.84, 1.23, 0.81, 0.99},
-        {1.23, 0.84, 0.93, 0.87}*/
+        {1.23, 0.84, 0.93, 0.87}
     };
 
     // Ausgabe der Eingabeinformationen


### PR DESCRIPTION
## Summary
- un-comment constant and array declarations in **Luftdruck-Messprogramm** so the program compiles

## Testing
- `g++ -x c++ Luftdruck-Messprogramm -o Luftdruck-Messprogramm.out`
- `./Luftdruck-Messprogramm.out | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68402eff8a58833288aefb6035a7d0be